### PR TITLE
Hashmap for Constraint Literals

### DIFF
--- a/allocation.py
+++ b/allocation.py
@@ -1,5 +1,5 @@
 import random, bisect
-from utility import is_egg, print_ln
+from utility import is_egg, print_ln, swap_constraint_progression
 
 class Allocation(object):
     # Attributes:
@@ -128,6 +128,8 @@ class Allocation(object):
     def construct_graph(self, data, settings):
         edges = list(data.initial_edges)
         edge_id = data.replacement_edges_id
+        edge_progression = {key: edge_ids.copy() for key,edge_ids in data.edge_progression.items()} 
+        
         originalNEdges = edge_id
         outgoing_edges = dict((key, list(edge_ids)) for key, edge_ids in data.initial_outgoing_edges.items())
         incoming_edges = dict((key, list(edge_ids)) for key, edge_ids in data.initial_incoming_edges.items())
@@ -138,6 +140,7 @@ class Allocation(object):
             key = (original_constraint.from_location, original_constraint.to_location)
             if key in edge_replacements:
                 constraint = edge_replacements[key]
+                swap_constraint_progression(edge_progression, edge_id, original_constraint.prereq_literals, constraint.prereq_literals)
             else:
                 constraint = original_constraint
             edges[edge_id].satisfied = constraint.prereq_lambda
@@ -158,9 +161,9 @@ class Allocation(object):
             incoming_edges[edge.to_location].append(edge.edge_id)
 
         self.edges = edges
+        self.edge_progression = edge_progression
         self.outgoing_edges = outgoing_edges
         self.incoming_edges = incoming_edges
-
 
     def shift_eggs_to_hard_to_reach(self, data, settings, reachable_items, hard_to_reach_items):
         reachable_items = set(reachable_items)

--- a/analyzer.py
+++ b/analyzer.py
@@ -152,12 +152,14 @@ class Analyzer(object):
         outgoing_edges = allocation.outgoing_edges
         incoming_edges = allocation.incoming_edges
         locations_set = data.locations_set
+        edge_progression = allocation.edge_progression
 
         # Persistent variables
         variables = dict(starting_variables)
         untraversable_edges = set(edge.edge_id for edge in edges)
         unreached_pseudo_items = dict(data.pseudo_items)
         unsatisfied_item_conditions = dict(data.alternate_conditions)
+        edge_progression_default = edge_progression['DEFAULT'].copy()
 
         forward_enterable = set((allocation.start_location.location,))
         backward_exitable = set(backward_exitable)
@@ -173,6 +175,7 @@ class Analyzer(object):
         new_reachable_locations = set()
         newly_traversable_edges = set()
         temp_variable_storage = {}
+        previous_new_variables = set() # for step 1 updating edges
 
         variables['IS_BACKTRACKING'] = False
         variables['BACKTRACK_DATA'] = untraversable_edges, outgoing_edges, edges
@@ -181,6 +184,10 @@ class Analyzer(object):
         first_loop = True
         current_level = 0
         reachable_levels = {allocation.start_location.location : 0}
+                
+        #step -1: Mark variables that start True (step 1 checks these)
+        previous_new_variables.update(var for var,val in variables.items() if val == True)
+
         while True:
             new_reachable_locations.clear()
             if first_loop: new_reachable_locations = forward_enterable.intersection(backward_exitable)
@@ -200,6 +207,7 @@ class Analyzer(object):
                         current_level_part1.append(target)
                         to_remove.append(target)
                         variables[target] = True
+                        previous_new_variables.add(target)
                         has_changes = True
 
                 for target in to_remove:
@@ -212,6 +220,7 @@ class Analyzer(object):
                         if not variables[target]:
                             current_level_part1.append(target)
                             variables[target] = True
+                            previous_new_variables.add(target)
                             has_changes = True
                         to_remove.append(target)
 
@@ -223,7 +232,8 @@ class Analyzer(object):
             forward_frontier.clear()
             backward_frontier.clear()
             newly_traversable_edges.clear()
-            for edge_id in untraversable_edges:
+            
+            def check_edge(edge_id):
                 edge = edges[edge_id]
                 if edge.satisfied(variables):
                     newly_traversable_edges.add(edge_id)
@@ -231,8 +241,19 @@ class Analyzer(object):
                         forward_frontier.add(edge.from_location)
                     if edge.to_location in backward_exitable:
                         backward_frontier.add(edge.to_location)
-            untraversable_edges -= newly_traversable_edges
-
+           
+            #check default always, then newly satisfied variables
+            for edge_id in edge_progression_default:
+                check_edge(edge_id)
+            edge_progression_default -= newly_traversable_edges
+            
+            for var in previous_new_variables:
+                for edge_id in edge_progression[var]:
+                    check_edge(edge_id)
+                    
+            previous_new_variables.clear()
+            untraversable_edges -= newly_traversable_edges   
+            
             # STEP 2: Find Forward Reachable Nodes
             new_forward_enterable = set()
             while len(forward_frontier) > 0:
@@ -347,7 +368,8 @@ class Analyzer(object):
 
             for node in current_level_part2:
                 variables[node] = True
-
+            previous_new_variables.update(current_level_part2)
+            
             if len(current_level_part1) == 0 and len(current_level_part2) == 0:
                 break
             levels.append(current_level_part1)

--- a/analyzer.py
+++ b/analyzer.py
@@ -234,6 +234,11 @@ class Analyzer(object):
             newly_traversable_edges.clear()
             
             def check_edge(edge_id):
+                nonlocal untraversable_edges, newly_traversable_edges
+                nonlocal forward_enterable, backward_exitable
+                nonlocal forward_frontier, backward_frontier
+                if edge_id not in untraversable_edges:
+                    return
                 edge = edges[edge_id]
                 if edge.satisfied(variables):
                     newly_traversable_edges.add(edge_id)

--- a/dataparser.py
+++ b/dataparser.py
@@ -469,7 +469,7 @@ def parse_item_constraints(settings, items_set, shufflable_gift_items_set, locat
 
     def parse_alternates(alts):
         if alts == None: return {}
-        return dict((name, parse_expression_lambda(constraint, variable_names_set, default_expressions))
+        return dict( (name, ExpressionData( parse_expression(constraint, variable_names_set, default_expressions)) )
             for name, constraint in alts.items())
 
     item_constraints = []
@@ -838,21 +838,23 @@ class RandomizerData(object):
                     backtrack_cost=0,
                 ))
 
-                for entry_node, prereq in item_constraint.alternate_entries.items():
+                for entry_node, expression_data in item_constraint.alternate_entries.items():
                     edges.append(GraphEdge(
                         edge_id=len(edges),
                         from_location=entry_node,
                         to_location=item_node_name,
-                        constraint=prereq,
+                        constraint=expression_data.exp_lambda,
+                        progression=expression_data.exp_literals,
                         backtrack_cost=1,
                     ))
 
-                for exit_node, prereq in item_constraint.alternate_exits.items():
+                for exit_node, expression_data in item_constraint.alternate_exits.items():
                     edges.append(GraphEdge(
                         edge_id=len(edges),
                         from_location=item_node_name,
                         to_location=exit_node,
-                        constraint=prereq,
+                        constraint=expression_data.exp_lambda,
+                        progression=expression_data.exp_literals,
                         backtrack_cost=1,
                     ))
 
@@ -923,7 +925,7 @@ class RandomizerData(object):
         self.initial_edges = edges
         self.initial_outgoing_edges = initial_outgoing_edges
         self.initial_incoming_edges = initial_incoming_edges
-        self.edge_progression = generate_progression_dict(self.variable_names_list, edges)
+        self.edge_progression = generate_progression_dict(self.variable_names_list, edges, keep_progression=False)
 
     def preprocess_data(self, settings):
         ### For item shuffle

--- a/dataparser.py
+++ b/dataparser.py
@@ -485,8 +485,8 @@ def parse_item_constraints(settings, items_set, shufflable_gift_items_set, locat
         item_constraints.append(ItemConstraintData(
             item = item,
             from_location = from_location,
-            entry_prereq = parse_expression_lambda(cdict['entry_prereq'], variable_names_set, default_expressions),
-            exit_prereq = parse_expression_lambda(cdict['exit_prereq'], variable_names_set, default_expressions),
+            entry_prereq = parse_expression(cdict['entry_prereq'], variable_names_set, default_expressions),
+            exit_prereq = parse_expression(cdict['exit_prereq'], variable_names_set, default_expressions),
             alternate_entries = parse_alternates(cdict.get('alternate_entries')),
             alternate_exits = parse_alternates(cdict.get('alternate_exits')),
         ))
@@ -825,6 +825,7 @@ class RandomizerData(object):
                     from_location=item_constraint.from_location,
                     to_location=item_node_name,
                     constraint=item_constraint.entry_prereq,
+                    progression=item_constraint.entry_progression,
                     backtrack_cost=0,
                 ))
 
@@ -833,6 +834,7 @@ class RandomizerData(object):
                     from_location=item_node_name,
                     to_location=item_constraint.from_location,
                     constraint=item_constraint.exit_prereq,
+                    progression=item_constraint.exit_progression,
                     backtrack_cost=0,
                 ))
 

--- a/dataparser.py
+++ b/dataparser.py
@@ -871,6 +871,7 @@ class RandomizerData(object):
                     from_location=graph_edge.from_location,
                     to_location=graph_edge.to_location,
                     constraint=graph_edge.prereq_lambda,
+                    progression=graph_edge.prereq_literals,
                     backtrack_cost=1,
                 ))
             else:
@@ -920,7 +921,7 @@ class RandomizerData(object):
         self.initial_edges = edges
         self.initial_outgoing_edges = initial_outgoing_edges
         self.initial_incoming_edges = initial_incoming_edges
-
+        self.edge_progression = generate_progression_dict(self.variable_names_list, edges)
 
     def preprocess_data(self, settings):
         ### For item shuffle

--- a/utility.py
+++ b/utility.py
@@ -136,8 +136,7 @@ class EdgeConstraintData(object):
         self.from_location = from_location
         self.to_location = to_location
         self.prereq_expression = prereq_expression
-        self.prereq_compile = compile(prereq_expression.compile(), "<node>", mode= "eval")
-        self.prereq_lambda = lambda v : eval(self.prereq_compile, None, {"variables": v})
+        self.prereq_lambda = ExpressionLambda(prereq_expression).expression_lambda
         self.prereq_literals = get_prereq_literals( prereq_expression )
 
     def __str__(self):
@@ -151,8 +150,10 @@ class ItemConstraintData(object):
     def __init__(self, item, from_location, entry_prereq, exit_prereq, alternate_entries, alternate_exits):
         self.item = item
         self.from_location = from_location
-        self.entry_prereq = entry_prereq
-        self.exit_prereq = exit_prereq
+        self.entry_prereq = ExpressionLambda( entry_prereq ).expression_lambda
+        self.exit_prereq  = ExpressionLambda( exit_prereq ).expression_lambda
+        self.entry_progression = get_prereq_literals( entry_prereq )
+        self.exit_progression  = get_prereq_literals(  exit_prereq )
         self.alternate_entries = alternate_entries
         self.alternate_exits = alternate_exits
         self.no_alternate_paths = (len(self.alternate_entries) + len(self.alternate_exits) == 0)

--- a/utility.py
+++ b/utility.py
@@ -84,13 +84,15 @@ def get_prereq_literals(prereq):
         return _always_check
     return literals_set
     
-def generate_progression_dict(variables_list, edges:'list<GraphEdge>') -> 'dict< str constraint = list<int edge_id>>':
+def generate_progression_dict(variables_list, edges:'list<GraphEdge>', keep_progression = True) -> 'dict< str constraint = list<int edge_id>>':
     progression = defaultdict(set)
     for v in variables_list: 
         progression[v] = set()
     for edge in edges:
         for literal in edge.progression:
             progression[literal].add(edge.edge_id)
+        if not keep_progression:
+            del edge.progression #no longer needed, saves space
     return progression
  
 def swap_constraint_progression(progression:dict, edge_id:int, old_progression:set, new_progression:set):
@@ -194,6 +196,13 @@ class ExpressionLambda(object):
         self.expression = expression
         self.expression_compile = compile(expression.compile(), "<node>", mode= "eval")
         self.expression_lambda = lambda v : eval(self.expression_compile, None, {"variables": v})
+
+class ExpressionData(object):
+    def __init__(self, exp):
+        self.exp = exp
+        compiled = compile(exp.compile(), "<node>", mode= "eval")
+        self.exp_lambda = lambda v : eval(compiled, None, {"variables": v})
+        self.exp_literals = get_prereq_literals( exp )
 
 class ConfigData(object):
     def __init__(self, knowledge, difficulty, settings):


### PR DESCRIPTION
Instead of always checking all untraversable_edges, only check affected edges ( shown by progression[newly_changed_variable] -> edge_ids:list )
Optimization implemented for EdgeConstraintData, ItemConstraintData, and ItemConstraintData.alternate_entry/exit
Tradeoff longer pre-process for faster time/attempt (roughly 5-10% speedup at vhard 100k attempts)