### PR TITLE
Fix riverbank_lower_exit_fireorb only loading one side of change

### DIFF
--- a/maptemplates/template_constraints.txt
+++ b/maptemplates/template_constraints.txt
@@ -671,6 +671,8 @@
             ))
         )
     ",
+    }
+    {
     "edge": "RIVERBANK_UNDERGROUND -> RIVERBANK_LOWER_LEFT",
     "prereq": "
         FIRE_ORB & (


### PR DESCRIPTION
In the changes list for `riverbank_lower_exit_fireorb`, the two edge replacements were listed in the same object, causing the first part to be overwritten by the first. Only the exit side, `RIVERBANK_UNDERGROUND -> RIVERBANK_LOWER_LEFT`, is replaced, with the entrance still expecting the default Carrot Bomb logic.